### PR TITLE
feat(wardend): Cosmovisor for wardend chart

### DIFF
--- a/charts/wardend/scripts/init-cosmovisor.sh
+++ b/charts/wardend/scripts/init-cosmovisor.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -x
+
+
+WARDEND_HOME="/root/.warden"
+COSMOVISOR_LOCATION="/root/.warden/cosmovisor/bin/cosmovisor"
+COSMOVISOR_URL="https://github.com/cosmos/cosmos-sdk/releases/download/cosmovisor%2F${COSMOVISOR_VERSION}/cosmovisor-${COSMOVISOR_VERSION}-linux-amd64.tar.gz"
+WARDEND_BINARY="$WARDEND_HOME/cosmovisor/genesis/bin/wardend"
+#Check if Home data exists, if not create it.
+if [ ! -d "$WARDEND_HOME/cosmovisor" ] || [ ! -d "$WARDEND_HOME/cosmovisor/genesis/bin" ] || [ ! -f "$COSMOVISOR_LOCATION" ]|| [ ! -f "$WARDEND_BINARY" ]; then
+  #Install utils
+  apt update 
+  apt install wget -y > /dev/null 2>&1
+
+  echo "Creating cosmovisor folders"
+  mkdir -p $WARDEND_HOME/cosmovisor/genesis/bin && mkdir -p $WARDEND_HOME/cosmovisor/genesis/upgrades
+  mkdir -p $WARDEND_HOME/cosmovisor/bin
+
+  echo "Downloading Cosmovisor"
+  # Download the file
+  wget -O /tmp/cosmovisor.tar.gz "$COSMOVISOR_URL"
+  # Check if the download was successful
+  if [ $? -eq 0 ]; then
+      echo "File downloaded successfully"
+      echo "Extracting the file..."
+      # Extract the file
+      tar -xzf /tmp/cosmovisor.tar.gz -C /tmp
+      
+      # Move the extracted file to the destination
+      mv /tmp/cosmovisor "$COSMOVISOR_LOCATION"
+      
+      # Check if the move was successful
+      if [ $? -eq 0 ]; then
+          echo "File moved to $COSMOVISOR_LOCATION successfully"
+      else
+          echo "Failed to move the file to $COSMOVISOR_LOCATION"
+      fi
+  else
+      echo "Failed to download the file from $COSMOVISOR_URL"
+  fi
+
+  if [ ! -f "$WARDEND_BINARY" ]; then
+    echo "Copying the Wardend binary as the genesis binary"
+  else
+    echo "Found Wardend binary, skipping!"
+  fi
+else
+  echo "Found Cosmovisor folder & binary, skipping!"
+fi

--- a/charts/wardend/scripts/init.sh
+++ b/charts/wardend/scripts/init.sh
@@ -1,13 +1,13 @@
 #!/usr/bin/env bash
 set -x
 
-#Install utils
-apt update 
-apt install curl jq -y > /dev/null 2>&1
 
 WARDEND_HOME="/root/.warden"
 #Check if Home data exists, if not create it.
 if [ ! -d "$WARDEND_HOME/data" ] && [ ! -d "$WARDEND_HOME/config" ]; then
+  #Install utils
+  apt update 
+  apt install curl jq -y > /dev/null 2>&1
   if [[ "$SYNC_METHOD" == "scratch" ]]; then
     /usr/bin/wardend init --chain-id "$WARDEND_CHAIN_ID" "$WARDEND_MONIKER"
     if [[ ! -z $WARDEN_GENESIS_RPC ]]; then

--- a/charts/wardend/templates/script.yaml
+++ b/charts/wardend/templates/script.yaml
@@ -6,3 +6,13 @@ metadata:
 data:
   init.sh: |
 {{ tpl (.Files.Get "scripts/init.sh") . | indent 4 }}
+---
+{{- if .Values.cosmovisor.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ .Release.Name }}-{{ .Values.node.name }}-cosmovisor-init"
+data:
+  init-cosmovisor.sh: |
+{{ tpl (.Files.Get "scripts/init-cosmovisor.sh") . | indent 4 }}
+{{- end }}

--- a/charts/wardend/templates/statefulset.yml
+++ b/charts/wardend/templates/statefulset.yml
@@ -56,6 +56,21 @@ spec:
               readOnly: true
             - name: {{ include "node.name" . }}-data
               mountPath: /root/.warden
+        {{- if .Values.cosmovisor.enabled }}
+        - name: init-cosmovisor
+          image: "{{ .Values.image }}:{{ .Values.imageTag | default .Chart.AppVersion }}"
+          command: [ "/bin/bash" , "/scripts/init-cosmovisor.sh" ]
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          env:
+            - name: COSMOVISOR_VERSION
+              value: "{{ .Values.cosmovisor.version }}"
+          volumeMounts:
+            - name: scripts-cosmovisor
+              mountPath: /scripts
+              readOnly: true
+            - name: {{ include "node.name" . }}-data
+              mountPath: /root/.warden
+        {{- end }}
         {{- if .Values.node.mnemonicSecretName }}
         - name: init-keys
           image: "{{ .Values.image }}:{{ .Values.imageTag | default .Chart.AppVersion }}"
@@ -79,11 +94,30 @@ spec:
         - name: {{ include "node.name" . }}
           image: "{{ .Values.image }}:{{ .Values.imageTag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+          {{- if .Values.cosmovisor.enabled }}
+          command: ["/root/.warden/cosmovisor/bin/cosmovisor","run","start"]
+          {{- else }}
           {{- if .Values.node.ready }}
           command: ["/usr/bin/wardend","start"]
-          {{- else}}
+          {{- else }}
           command: ["sleep","36000"]
-          {{- end}}
+          {{- end }}
+          {{- end }}
+          {{- if .Values.cosmovisor.enabled }}
+          env:
+            - name: DAEMON_NAME
+              value: "wardend"
+            - name: DAEMON_HOME
+              value: "/root/.warden"
+            - name: DAEMON_RESTART_AFTER_UPGRADE
+              value: "{{ .Values.cosmovisor.restartAfterUpgrade }}"
+            - name: DAEMON_ALLOW_DOWNLOAD_BINARIES
+              value: "{{ .Values.cosmovisor.allowDownloadBinaries }}"
+            - name: DAEMON_LOG_BUFFER_SIZE
+              value: "{{ .Values.cosmovisor.logBufferSize }}"
+            - name: UNSAFE_SKIP_BACKUP
+              value: "{{ .Values.cosmovisor.unsafeSkipBackup }}"
+          {{- end }}
           ports:
             {{- if .Values.node.rpc.enabled }}
             - name: rpc
@@ -153,6 +187,11 @@ spec:
       - name: scripts
         configMap:
           name: {{.Release.Name}}-{{ .Values.node.name }}-scripts
+      {{- if .Values.cosmovisor.enabled }}
+      - name: scripts-cosmovisor
+        configMap:
+          name: {{ .Release.Name }}-{{ .Values.node.name }}-cosmovisor-init
+      {{- end }}
       - name: config
         configMap:
           name: {{ .Release.Name }}-{{ .Values.node.name }}-config

--- a/charts/wardend/values.yaml
+++ b/charts/wardend/values.yaml
@@ -4,7 +4,7 @@
 # Declare variables to be passed into your templates.
 image: ghcr.io/warden-protocol/wardenprotocol/wardend
 imagePullPolicy: IfNotPresent
-imageTag: "v0.3.0-rc1"
+imageTag: "v0.3.0"
 
 imagePullSecrets: []
 
@@ -33,6 +33,14 @@ scratch:
 
 moniker: mynode
 minGasPrice: 0uward
+
+cosmovisor:
+  enabled: false
+  version: "v1.5.0"
+  restartAfterUpgrade: true
+  allowDowloadBinaries: true
+  logBufferSize: "512"
+  unsafeSkipBackup: true
 
 node:
   enabled: true


### PR DESCRIPTION
This PR will enable users to use cosmovisor to run their nodes.
It can be used for automatic upgrades.

There is also a small fix for wardend init script to speed up the init phase.