### PR TITLE
Fix (wardend): EIP check

### DIFF
--- a/charts/wardend/Chart.yaml
+++ b/charts/wardend/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.4.2
+version: 2.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/wardend/scripts/init.sh
+++ b/charts/wardend/scripts/init.sh
@@ -1,18 +1,6 @@
 #!/usr/bin/env bash
 set -x
 
-# Check EIP
-if [ -n "$EIP_CHECK" ]; then
-    while true; do
-        if [ -n "$EIP" ]; then
-            echo "EIP is set: $EIP";
-            exit 0;
-        fi
-        echo "Waiting for EIP.";
-        sleep 15;
-    done
-fi
-
 #Check if Home data exists, if not create it.
 if [ ! -d "$WARDEND_HOME/data" ] && [ ! -d "$WARDEND_HOME/config" ]; then
     #Install utils

--- a/charts/wardend/templates/statefulset.yml
+++ b/charts/wardend/templates/statefulset.yml
@@ -77,15 +77,6 @@ spec:
             - name: GENESIS_URL
               value: "{{ .Values.scratch.genesisUrl }}"
             {{- end}}
-            {{- if and .Values.eipController.enabled .Values.eipController.check }}
-            - name: EIP
-              valueFrom:
-                fieldRef:
-                  apiVersion: v1
-                  fieldPath: metadata.labels['aws-pod-eip-controller-public-ip']
-            - name: EIP_CHECK
-              value: "{{ .Values.eipController.check }}"
-            {{- end }}
           volumeMounts:
             - name: scripts
               mountPath: /scripts
@@ -216,6 +207,11 @@ spec:
             - name: WARDEND_P2P_EXTERNAL_ADDRESS
               value: $(EIP):26656
           {{- end }}
+          {{- if and .Values.eipController.enabled .Values.eipController.check }}
+            - name: EIP_CHECK
+              value: "{{ .Values.eipController.check }}"
+          {{- end }}
+          volumeMounts:
           ports:
             {{- if .Values.node.rpc.enabled }}
             - name: rpc
@@ -256,9 +252,18 @@ spec:
           {{- if not .Values.node.externalSigner }}
           readinessProbe:
             initialDelaySeconds: 10
-            httpGet:
-              path: /health
-              port: rpc
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  if [ -z "$EIP_CHECK"]; then
+                  if [ -z "$EIP" ]; then
+                    echo "EIP is not set or empty"
+                    exit 1
+                  fi
+                  fi
+                  curl -f http://localhost:26656/health || exit 1
           {{- end }}
           {{- end }}
           volumeMounts:

--- a/charts/wardend/templates/statefulset.yml
+++ b/charts/wardend/templates/statefulset.yml
@@ -263,7 +263,7 @@ spec:
                     exit 1
                   fi
                   fi
-                  curl -f http://localhost:26656/health || exit 1
+                  curl -f http://localhost:26657/health || exit 1
           {{- end }}
           {{- end }}
           volumeMounts:


### PR DESCRIPTION
EIP check doesn't work until container (not Initcontainer) started. So we can use EIP checking only in Readiness/LivenessProbe